### PR TITLE
Use array_key_exists() instead of array_keys() and in_array()

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,7 +2,7 @@
 require 'config.php';
 
 $lang = (isset($_GET['lang'])) ? $_GET['lang'] : 'en';
-if ( !in_array($lang, array_keys($dbs))) {
+if ( !array_key_exists($lang, $dbs)) {
     $err = "The language '$lang' has not yet been included. Please lodge an issue.";
 }
 $suffix = $lang=='en' ? '' : '_'.$lang;


### PR DESCRIPTION
According to @thiemowmde at http://maettig.com/1397246220:
"never ever do `in_array( $key, array_keys( $array ) )`, that's just stupid"
